### PR TITLE
Changed the color-scheme of tags for visibility in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,4 @@
-
-        /* Base styles */
+/* Base styles */
         * {
             margin: 0;
             padding: 0;
@@ -526,6 +525,13 @@
             display: inline-block;
             white-space: nowrap;
         }
+/* Dark mode fix for tags */
+body.dark-theme .tag-badge {
+    background-color: rgba(102, 126, 234, 0.2); /* subtle purple tint */
+    color: #ffffff; /* bright white text */
+    border: 1px solid rgba(102, 126, 234, 0.4); /* soft border */
+}
+
 
         .upvote-section {
             display: flex;


### PR DESCRIPTION
modified the CSS file a little bit to make the tech-stack tags completely visible in dark-mode. here are the before vs after screenshots to compare:
<img width="1920" height="874" alt="Screenshot (48)" src="https://github.com/user-attachments/assets/95e696cb-8eee-4598-ace2-07f8b54cdf4e" />
<img width="1920" height="866" alt="Screenshot (70)" src="https://github.com/user-attachments/assets/79dda79a-59bd-4b08-b5be-b0c046064c64" />
